### PR TITLE
Add a missing parameter.

### DIFF
--- a/src/electron/driver.lisp
+++ b/src/electron/driver.lisp
@@ -201,4 +201,4 @@
                  :operating-system *operating-system*
                  :architecture *architecture*
                  :version *electron-version*)
-    (prepare-release (release-directory))))
+    (prepare-release (release-directory) :operating-system *operating-system*)))


### PR DESCRIPTION
The `prepare-release` function expects `:operating-system` as a
parameter. If it's missing, the function will use an incorrect
release directory on some operating systems.

Fixes #2 "(ceramic:setup) fails on OS X"
