### PR TITLE
ceramic.lisp define-entry-point already finds the full binary pathnam…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ script:
 
 notifications:
   email:
-    - eudoxiahp@gmail.com
+    - joshua.kordani@gmail.com

--- a/src/bundler.lisp
+++ b/src/bundler.lisp
@@ -61,12 +61,12 @@ most people can unzip)."
            (copy-resources (merge-pathnames #p"resources/"
                                             work-directory))
            ;; Copy the electron directory
-           (copy-directory (ceramic.electron:release-directory)
-                           electron-directory)
-           ;; Ensure Electron is executable
-           (ensure-executable
-            (binary-pathname electron-directory
-                             :operating-system *operating-system*))
+           ;; (copy-directory (ceramic.electron:release-directory)
+           ;;                 electron-directory)
+           ;; ;; Ensure Electron is executable
+           ;; (ensure-executable
+           ;;  (binary-pathname electron-directory
+           ;;                   :operating-system *operating-system*))
            ;; Compile the app
            (tell "Compiling app...")
            (ceramic.build:build :eval +prelude+
@@ -81,7 +81,8 @@ most people can unzip)."
              (tell "Found existing bundle, deleting...")
              (delete-file bundle-pathname))
            (tell "Compressing...")
-           (create-archive work-directory bundle-pathname))
-      (uiop:delete-directory-tree work-directory :validate t)
+           ;; (create-archive work-directory bundle-pathname)
+	   )
+      ;; (Uiop:delete-directory-tree work-directory :validate t)
       (tell "Done!")
       bundle-pathname)))

--- a/src/electron/driver.lisp
+++ b/src/electron/driver.lisp
@@ -58,7 +58,7 @@
   "Start an Electron process, returning the process object."
   (let ((binary-pathname (binary-pathname directory
                                           :operating-system operating-system)))
-    (external-program:start binary-pathname
+    (external-program:start directory
                             (list)
                             :input :stream
                             :output :stream)))

--- a/src/electron/driver.lisp
+++ b/src/electron/driver.lisp
@@ -184,7 +184,7 @@
 
 ;;; Interface
 
-(defvar *electron-version* "0.28.1"
+(defvar *electron-version* "0.30.2"
   "The version of Electron to use.")
 
 (defun release-directory ()


### PR DESCRIPTION
…e before passing to start-process.  doing this again inside of start process results in a bad path being passed.  only tested on osx.  I imagine that error handling would also be desired here.  I wonder how this was working on other platforms....
