### PR TITLE
ceramic.lisp define-entry-point already finds the full binary pathnam…

### DIFF
--- a/src/electron/driver.lisp
+++ b/src/electron/driver.lisp
@@ -58,7 +58,7 @@
   "Start an Electron process, returning the process object."
   (let ((binary-pathname (binary-pathname directory
                                           :operating-system operating-system)))
-    (external-program:start binary-pathname
+    (external-program:start directory
                             (list)
                             :input :stream
                             :output :stream)))


### PR DESCRIPTION
…e before passing to start-process.  doing this again inside of start process results in a bad path being passed.  only tested on osx

figured it out.  the original PR was against my master branch, no matter its state.  as I continued to push changes to master, the PR gets updated.  I had to make a new remote for your project, cherry pick just this commit onto it, and then push it to my github in order to make the branch show up here for the PR.

whew!
