### PR TITLE
Load system not located in default quicklisp search locations.

### DIFF
--- a/src/bundler.lisp
+++ b/src/bundler.lisp
@@ -32,11 +32,6 @@ most people can unzip)."
       "tar"))
 
 (defun create-archive (directory output)
-  (if (eq *operating-system* :windows)
-      (zip-up directory output)
-      (tar-up directory output)))
-
-(defun create-archive (directory output)
   (case *operating-system*
     (:windows
      (zip-up directory output))


### PR DESCRIPTION
By default Quicklisp only loads systems from its dists/ folder or the local-projects/ folder. This change adds a new key parameter to allow loading a system from an arbitrary location.
