### PR TITLE
Assorted changes from a Ceramic newbie

### DIFF
--- a/src/ceramic.lisp
+++ b/src/ceramic.lisp
@@ -155,29 +155,15 @@
                :documentation "Whether or not the window is resizable."))
   (:documentation "A browser window."))
 
-(defun make-window (&key title url x y width height
+(defun make-window (&rest args
+                    &key title url x y width height
                       min-width min-height max-width max-height
-                      (resizablep t) node-integration-p)
+                      resizablep node-integration-p)
   "Create a window."
-  (let ((args (list*
-               (cons :resizablep resizablep)
-               (cons :node-integration-p node-integration-p)
-               (remove-if #'(lambda (pair)
-                              (null (rest pair)))
-                          (list (cons :title title)
-                                (cons :url url)
-                                (cons :x x)
-                                (cons :y y)
-                                (cons :width width)
-                                (cons :height height)
-                                (cons :min-width min-width)
-                                (cons :min-height min-height)
-                                (cons :max-width max-width)
-                                (cons :max-height max-height))))))
-    (apply #'make-instance
-           (cons 'window
-                 (loop for (key . value) in args appending
-                   (list key value))))))
+  (declare (ignore title url x y width height
+                   min-width min-height max-width max-height
+                   resizablep node-integration-p))
+  (apply #'make-instance 'window args))
 
 ;;; Setters
 

--- a/src/ceramic.lisp
+++ b/src/ceramic.lisp
@@ -143,6 +143,11 @@
                :initarg :max-height
                :type integer
                :documentation "The window's maximum height, in pixels.")
+   (node-integration-p :reader node-integration-p
+                       :initarg :node-integration-p
+                       :initform nil
+                       :type boolean
+                       :documentation "Whether node integration is enabled.")
    (resizablep :reader window-resizable-p
                :initarg :resizablep
                :initform t
@@ -152,10 +157,11 @@
 
 (defun make-window (&key title url x y width height
                       min-width min-height max-width max-height
-                      resizablep)
+                      resizablep node-integration-p)
   "Create a window."
-  (let ((args (cons
+  (let ((args (list*
                (cons :resizablep resizablep)
+               (cons :node-integration-p node-integration-p)
                (remove-if #'(lambda (pair)
                               (null (rest pair)))
                           (list (cons :title title)
@@ -247,6 +253,8 @@
                          (slot min-height "min-height")
                          (slot max-width "max-width")
                          (slot max-height "max-height")
+                         (list (cons "node-integration"
+                                     (cl-json:json-bool (node-integration-p window))))
                          (list (cons "resizable"
                                      (cl-json:json-bool (window-resizable-p window))))))
     (when (slot-boundp window 'url)

--- a/src/ceramic.lisp
+++ b/src/ceramic.lisp
@@ -157,7 +157,7 @@
 
 (defun make-window (&key title url x y width height
                       min-width min-height max-width max-height
-                      resizablep node-integration-p)
+                      (resizablep t) node-integration-p)
   "Create a window."
   (let ((args (list*
                (cons :resizablep resizablep)

--- a/src/ceramic.lisp
+++ b/src/ceramic.lisp
@@ -343,8 +343,7 @@
   (let ((entry-point (intern (symbol-name system-name)
                              (find-package :ceramic-entry)))
         (arguments (gensym))
-        (electron-directory (gensym))
-        (binary (gensym)))
+        (electron-directory (gensym)))
     `(defun ,entry-point (,arguments)
        (declare (ignore ,arguments))
        ;; Start the executable-relative Electron process

--- a/src/ceramic.lisp
+++ b/src/ceramic.lisp
@@ -63,7 +63,9 @@
       nil
       ;; We're in a dev environment
       (progn
-        (when *process*
+        (when (and *process*
+                   (eq (external-program:process-status *process*)
+                       :running))
           (warn "Interactive process already running. Restarting.")
           (stop-interactive))
         (setf *process*


### PR DESCRIPTION
Having tried Ceramic for the first time, I stumbled upon a couple of issues:
1. I had a prototype using plain html+js that worked but then failed when running under Ceramic. I traced it down to https://github.com/atom/electron/issues/254. I argue that most Ceramic users don't care about node.js so disabling `node-integration` by default is a good idea, but I could be wrong. :-) (Perhaps a more general mechanism for customizing other `BrowserWindow` properties would make sense, but I'm just scratching my own itch here.)
2. The Electron window was not resizable and that seemed like a strange default, IMHO.
3. After closing the Electron window, subsequent calls to `ceramic:interactive` yielded an error due to `ceramic:stop-interactive` trying to kill a nonexistent process.

This pull request attempts to fix these issues along with a minor refactoring of `ceramic:make-window` and a minor cleanup to `ceramic:define-entry-point`.
