### PR TITLE
Make the websocket address configurable

### DIFF
--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -99,6 +99,12 @@
   (:method ((driver driver))
     (remote-js:context-port (driver-context driver))))
 
+(defgeneric address (driver)
+  (:documentation "Return the address the WebSockets server is running on.")
+
+  (:method ((driver driver))
+    (remote-js:context-address (driver-context driver))))
+
 ;;; IPC
 
 (defgeneric on-message (driver message)
@@ -120,10 +126,11 @@
                        (release-directory))))
     (with-slots (process) driver
       (setf process
-            (external-program:start (print (binary-pathname directory
-                                                            :operating-system ceramic.os:*operating-system*))
+            (external-program:start (binary-pathname directory
+                                                     :operating-system ceramic.os:*operating-system*)
                                     (list (app-directory directory
                                                          :operating-system ceramic.os:*operating-system*)
+                                          (address driver)
                                           (write-to-string (port driver)))
                                     :output (when *logging* *standard-output*)
                                     :error :output))))
@@ -143,7 +150,8 @@
   "Start the remote-js server."
   (with-slots (context) driver
     (setf context
-          (remote-js:make-buffered-context :callback
+          (remote-js:make-buffered-context :address "localhost"
+                                           :callback
                                            #'(lambda (message)
                                                (on-message driver message))))
     (remote-js:start context))

--- a/src/main.js
+++ b/src/main.js
@@ -10,8 +10,8 @@ var Ceramic = {};
 
 var RemoteJS = {};
 
-Ceramic.startWebSockets = function(port) {
-  RemoteJS.ws = new WebSocket('ws://127.0.0.1:' + port);
+Ceramic.startWebSockets = function(address, port) {
+  RemoteJS.ws = new WebSocket('ws://' + address + ':' + port);
 
   RemoteJS.send = function(data) {
     RemoteJS.ws.send(data);
@@ -78,5 +78,6 @@ app.on('window-all-closed', function() {
 
 app.on('ready', function() {
   // Start the WebSockets server
-  Ceramic.startWebSockets(parseInt(process.argv[2]));
+  Ceramic.startWebSockets(process.argv[2],
+                          parseInt(process.argv[3]));
 });


### PR DESCRIPTION
Default it to 'localhost'. Now it is safe to use localhost because
both Electron and the websocket server are guaranteed to run on the
same IP address and on the same network interface, even if IPV6 is
enabled.
