### PR TITLE
run on linux, but error on other unix

### DIFF
--- a/src/os.lisp
+++ b/src/os.lisp
@@ -14,7 +14,7 @@
      :windows)
     ((uiop:os-macosx-p)
      :mac)
-    ((uiop:os-unix-p)
+    ((equal (uiop:operating-system) :linux) ;;but not BSDs and other *nix
      :linux)
     (t
      (error 'unsupported-operating-system


### PR DESCRIPTION
With uiop:os-unix-p ceramic silently fails on unixes other than linux - first in (ceramic:setup) it downloads linux electron binary and then silently waits forever in (ceramic:start). So rather then testing for os-unix-p it should be testing specifically for linux.

Tested on debian and openbsd.