### PR TITLE
Updating setup electron version and adding few options of createWindow

### DIFF
--- a/src/setup.lisp
+++ b/src/setup.lisp
@@ -75,7 +75,7 @@
 
 ;;; Main
 
-(defparameter *electron-version* "1.2.7"
+(defparameter *electron-version* "5.0.2"
   "The version of Electron to use.")
 
 (defun setup (&key force)

--- a/src/window.lisp
+++ b/src/window.lisp
@@ -67,6 +67,7 @@
 			   :transparent transparent
 			   :resizable resizable))))
           (win (make-instance class)))
+      (format t "options: ~A" options)
       (with-slots (%id) win
         (js "Ceramic.windows[~S] = Ceramic.createWindow(~S, ~A)" %id (or url "null") options))
       win)))

--- a/src/window.lisp
+++ b/src/window.lisp
@@ -51,7 +51,7 @@
         :documentation "A unique string ID for the window."))
   (:documentation "A browser window."))
 
-(defun make-window (&key title url width height (class 'window))
+(defun make-window (&key title url width height frame show transparent resizable (class 'window))
   "Create a window."
   (flet ((remove-null-values (plist)
            (loop for (key value) on plist by #'cddr
@@ -61,7 +61,11 @@
                     (remove-null-values
                      (list :title title
                            :width width
-                           :height height))))
+                           :height height
+			   :frame frame
+			   :show show
+			   :transparent transparent
+			   :resizable resizable))))
           (win (make-instance class)))
       (with-slots (%id) win
         (js "Ceramic.windows[~S] = Ceramic.createWindow(~S, ~A)" %id (or url "null") options))

--- a/src/window.lisp
+++ b/src/window.lisp
@@ -57,17 +57,19 @@
            (loop for (key value) on plist by #'cddr
                  if value
                  appending (list key value))))
-    (let ((options (cl-json:encode-json-plist-to-string
-                    (remove-null-values
-                     (list :title title
-                           :width width
-                           :height height
-			   :frame frame
-			   :show show
-			   :transparent transparent
-			   :resizable resizable))))
+    (let ((options (cl-ppcre:regex-replace-all
+		    ":\"true\""
+		    (cl-json:encode-json-plist-to-string
+		     (remove-null-values
+		      (list :title title
+			    :width width
+			    :height height
+			    :frame frame
+			    :show show
+			    :transparent transparent
+			    :resizable resizable)))
+		    ":true"))
           (win (make-instance class)))
-      (format t "options: ~A" options)
       (with-slots (%id) win
         (js "Ceramic.windows[~S] = Ceramic.createWindow(~S, ~A)" %id (or url "null") options))
       win)))
@@ -92,6 +94,7 @@
 (define-trivial-operation crashedp "webContents.isCrashed()"
   :docstring "Return whether the window has crashed."
   :sync t)
+
 
 ;;; Getters
 


### PR DESCRIPTION
# src/setup.lisp

- Update the version of Electron from 1.2.7 to 5.0.2

# src/window.lisp

1.  adding function ((cl-ppcre:regex-replace-all) to replace createWindow's option string.
2. adding make-window parameter which are options of createWindow function 
(frame, show, transparent, resizable)

## Reason why I added these changes

### For 1

- The version of electron was too legacy.

### For 2

- I wished to make window (created by ceramic) opaque for making desktop mascot in Common Lisp. But, I could not deal with the opacity of the window.
- When I tried to make trivial-operation for setOpacity(Electron API) by using "define-trivial-operation, it makes all object, include mascot objects, transparent.
- So, it must become able to implement ceramic:make-window as below

```
(make-window :url "http://localhost:5000")
			     :title "transparent ceramic"
			     :transparent "true")
```

- I added this change and test it, but any change did not appear.
- I found the shape of options list is formed looks like "{\"title\":\"trans\",\"frame\":\"false\",\"transparent\":\"true\"}"
- In order to activate the options which has true-false value, the sentence must be looks like below

```
"{\"title\":\"trans\", \"transparent\":true}"
```

- Therefore, I added "cl-ppcre:regex-replace-all" function for the options of createWindow.

- That's why I send this request.
